### PR TITLE
remove domain when setting cookies

### DIFF
--- a/lib/dev-rest-proxy.js
+++ b/lib/dev-rest-proxy.js
@@ -12,13 +12,19 @@ module.exports.proxy = function(req, res, server, port, pathToStrip){
         headers: {}
     };
 
-	if (pathToStrip && options.path.substring(0, pathToStrip.length) === pathToStrip) {
-        options.path = options.path.substring(pathToStrip.length)
+    if (pathToStrip && options.path.substring(0, pathToStrip.length) === pathToStrip) {
+        options.path = options.path.substring(pathToStrip.length);
     }
 
     options.headers = req.headers;
 
     var callback = function(response) {
+
+        if (response.headers['set-cookie']) {
+            response.headers['set-cookie'] = response.headers['set-cookie'].map(function (cookie) {
+                return cookie.replace(/; ?domain=[^;]*/ig, '');
+            });
+        }
 
         res.writeHead(response.statusCode, response.headers);
         response.on('data', function (chunk) {
@@ -38,4 +44,4 @@ module.exports.proxy = function(req, res, server, port, pathToStrip){
         request.end();
     });
 
-}
+};


### PR DESCRIPTION
This allows the proxy to work when the server being proxied sets cookies on specific domains.
